### PR TITLE
fix y and d, add c action

### DIFF
--- a/keymap.json
+++ b/keymap.json
@@ -249,7 +249,7 @@
       ".": "vim::Repeat",
       "shift-d": "vim::DeleteToEndOfLine",
       "shift-j": "vim::JoinLines",
-      "y": "vim::Yank",
+      "y": "editor::Copy",
       "shift-y": "vim::YankLine",
       "i": "vim::InsertBefore",
       "shift-i": "vim::InsertFirstNonWhitespace",
@@ -336,7 +336,8 @@
       // "ctrl-v": "editor::Paste",
       "shift-u": "editor::Redo",
       "ctrl-c": "editor::ToggleComments",
-      "d": "editor::Delete" // TODO: yank first
+      "d": ["workspace::SendKeystrokes", "y d"],
+      "c": ["workspace::SendKeystrokes", "d i"]
     }
   },
   {


### PR DESCRIPTION
I use the <kbd>c</kbd> action all the time in helix. Also, I fixed the <kbd>d</kbd> key bind so it yanks before deleting. This was possible because I modified <kbd>y</kbd> to use the `"editor::Copy"` instead of `"vim::Yank"`. Maybe there is a tradeoff that I am not aware of, but this makes the most sense to me and it works great.